### PR TITLE
Add DOM utilities: getDOMNode, getAttribute and getClassName

### DIFF
--- a/lib/pageObject.js
+++ b/lib/pageObject.js
@@ -14,6 +14,9 @@ function PageObject(props) {
   }
 
   this.dispose = dispose;
+  this.getDOMNode = getDOMNode;
+  this.getAttribute = getAttribute;
+  this.getClassName = getClassName;
 
   wrapComponentDidUpdate(this.element, this);
 
@@ -52,6 +55,18 @@ function PageObject(props) {
 
   function dispose() {
     React.unmountComponentAtNode(this.element.getDOMNode().parentNode);
+  }
+
+  function getDOMNode() {
+    return this.element.getDOMNode();
+  }
+
+  function getAttribute(attributeName) {
+    return getDOMNode().getAttribute(attributeName);
+  }
+
+  function getClassName() {
+    return getAttribute("class");
   }
 }
 

--- a/lib/pageObject.js
+++ b/lib/pageObject.js
@@ -62,11 +62,11 @@ function PageObject(props) {
   }
 
   function getAttribute(attributeName) {
-    return getDOMNode().getAttribute(attributeName);
+    return this.getDOMNode().getAttribute(attributeName);
   }
 
   function getClassName() {
-    return getAttribute("class");
+    return this.getAttribute("class");
   }
 }
 

--- a/test/fixtures/loginPage.js
+++ b/test/fixtures/loginPage.js
@@ -6,7 +6,7 @@ var AuthService = require("./services/authService");
 var LoginPage = React.createClass({
   render: function () {
     return (
-      <div className="login-page">
+      <div className="login-page" id="login-page">
 
         <input ref="email"
                type="text"

--- a/test/simplePageObject.js
+++ b/test/simplePageObject.js
@@ -17,13 +17,16 @@ var LoginPageObject = PageObject.extend({
 });
 
 describe("PageObject", function () {
-  var page, authenticate;
+  var page, authenticate, className, domNode, id;
   var email = "foo@bar.com", password = "password";
 
   beforeEach(function () {
     authenticate = sinon.spy(AuthService, "authenticate");
     page = new LoginPageObject();
     page.loginAs(email, password);
+    className = page.getClassName();
+    domNode = page.getDOMNode();
+    id = page.getAttribute("id");
   });
 
   afterEach(function () {
@@ -37,5 +40,17 @@ describe("PageObject", function () {
 
   it("should simulate clicks", function () {
     expect(authenticate).to.have.been.calledWith(email, password);
+  });
+
+  it("should proxy getAttribute", function () {
+    expect(id).to.equal(page.getDOMNode().getAttribute("id"));
+  });
+
+  it("should proxy getDOMNode", function () {
+    expect(domNode).to.equal(page.getDOMNode());
+  });
+
+  it("should proxy getClassName", function () {
+    expect(className).to.equal(page.getDOMNode().getAttribute("class"));
   });
 });


### PR DESCRIPTION
After working with `react-page-objects` for a while I find myself using the same boilerplate over and over for accessing attributes and DOM nodes. This PR adds the following utility methods to reduce this boilerplate:
* getDOMNode: proxies `element.getDOMNode()`
* getAttribute: proxies `element.getDOMNode().getAttribute()`
* getClassName: proxies `element.getDOMNode().getAttribute("class")`

@jhollingworth do you want tests on these?